### PR TITLE
Fixing warnings

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -36,9 +36,14 @@ class curator::repo {
         location    => "http://packages.elastic.co/curator/${curator::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
-        key_server  => 'pgp.mit.edu',
-        include_src => false,
+        key         => {
+          id => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+          server => 'pgp.mit.edu'
+        },
+        include => {
+          src => false,
+          deb => true
+        }
       }
     }
     'RedHat': {

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,8 @@
   "operatingsystem_support": [
     { "operatingsystem": "RedHat", "operatingsystemrelease": [ "6", "7" ] },
     { "operatingsystem": "CentOS", "operatingsystemrelease": [ "6", "7" ] },
-    { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "12.04", "14.04" ] }
+    { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "12.04", "14.04" ] },
+    { "operatingsystem": "Debian", "operatingsystemrelease": [ "8" ] }
   ],
   "dependencies": [
     { "name": "puppetlabs/apt", "version_requirement": ">=2.2.0" },


### PR DESCRIPTION
This fixes some warnings, when using puppet on debian jessie.